### PR TITLE
feat(cli): Add `--env` argument, pass environment variables to docker

### DIFF
--- a/src/docker_wrapper/cli.py
+++ b/src/docker_wrapper/cli.py
@@ -271,6 +271,7 @@ def create_cli(
         privileged: bool = typer.Option(False, help="Enable Docker privileged mode"),
         ports: Optional[List[str]] = typer.Option(None, help="Port to forward from Docker"),
         volume: Optional[List[str]] = typer.Option(None, help="Volume to mount"),
+        env: Optional[List[str]] = typer.Option(None, help="Environment variables to pass"),
         sudo: bool = typer.Option(True, help="Enable sudo inside the container"),
     ) -> None:
         """
@@ -281,11 +282,13 @@ def create_cli(
         image.run(
             prompt=prompt,
             cmds=cmds,
+            mount_home=mount_home,
             project_dir=project_dir,
             network=network,
             privileged=privileged,
             ports=ports,
             volumes=volume,
+            envs=env,
             enable_sudo=sudo,
         )
 

--- a/src/docker_wrapper/docker_helpers.py
+++ b/src/docker_wrapper/docker_helpers.py
@@ -154,6 +154,7 @@ class DockerImage:
         enable_gui: bool = False,
         ports: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
+        envs: Optional[List[str]] = None,
         enable_sudo: bool = False,
     ) -> None:
         """Run a container from the Docker Image
@@ -234,6 +235,9 @@ class DockerImage:
                 "-v",
                 home_dir + ":" + home_dir,
             ]
+        if envs:
+            for env in envs:
+                cmd += ["-e", env]
         cmd += [
             "-v",
             f"{project_realpath}:{project_realpath}",


### PR DESCRIPTION
This commit replicates the docker `--env` option in our CLI so that we can pass environment variables to docker

Resolves #16